### PR TITLE
Fix flaky test in SimpleCrane4jGlobalConfigurationTest

### DIFF
--- a/crane4j-core/src/test/java/cn/crane4j/core/support/SimpleCrane4jGlobalConfigurationTest.java
+++ b/crane4j-core/src/test/java/cn/crane4j/core/support/SimpleCrane4jGlobalConfigurationTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * test for {@link SimpleCrane4jGlobalConfiguration}
@@ -38,7 +39,7 @@ public class SimpleCrane4jGlobalConfigurationTest {
         strategies.stream().map(PropertyMappingStrategy::getName).forEach(configuration::removePropertyMappingStrategy);
         Assert.assertTrue(configuration.getAllPropertyMappingStrategies().isEmpty());
         strategies.forEach(configuration::addPropertyMappingStrategy);
-        Assert.assertEquals(strategies, new ArrayList<>(configuration.getAllPropertyMappingStrategies()));
+        Assert.assertEquals(new HashSet<>(strategies), new HashSet<>(configuration.getAllPropertyMappingStrategies()));
     }
 
     @Test


### PR DESCRIPTION
Change Assert condition to compare two sets instead of lists to make the test non-flaky.

**Flaky test**

```
cn.crane4j.core.support.SimpleCrane4jGlobalConfigurationTest#operatePropertyMappingStrategy
```

https://github.com/bbelide2/crane4j/blob/b65f7324544381646119be48393f0aa2b3417f2e/crane4j-core/src/test/java/cn/crane4j/core/support/SimpleCrane4jGlobalConfigurationTest.java#L34

### Problem

Test ```operatePropertyMappingStrategy``` in ```SimpleCrane4jGlobalConfigurationTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:

```
Running cn.crane4j.core.support.SimpleCrane4jGlobalConfigurationTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.257 sec <<< FAILURE!
operatePropertyMappingStrategy(cn.crane4j.core.support.SimpleCrane4jGlobalConfigurationTest)  Time elapsed: 0.003 sec  <<< FAILURE!
java.lang.AssertionError: expected:<[cn.crane4j.core.parser.handler.strategy.ReferenceMappingStrategy@3e694b3f, cn.crane4j.core.parser.handler.strategy.OverwriteNotNullMappingStrategy@1bb5a082, cn.crane4j.core.parser.handler.strategy.OverwriteMappingStrategy@78691363]> but was:<[cn.crane4j.core.parser.handler.strategy.OverwriteMappingStrategy@78691363, cn.crane4j.core.parser.handler.strategy.OverwriteNotNullMappingStrategy@1bb5a082, cn.crane4j.core.parser.handler.strategy.ReferenceMappingStrategy@3e694b3f]>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at cn.crane4j.core.support.SimpleCrane4jGlobalConfigurationTest.operatePropertyMappingStrategy(SimpleCrane4jGlobalConfigurationTest.java:41)
```

### Root cause

Multiple objects of class ```PropertyMappingStrategy``` are added to the ```configuration``` object of class ```SimpleCrane4jGlobalConfiguration``` using the ```addPropertyMappingStrategy``` function. These strategy objects are stored as a HashMap in ```SimplePropertyMappingStrategyManager```.  To test whether they are added correctly or not, all the strategies are fetched using function ```getAllPropertyMappingStrategies()``` which is converted to a ArrayList for assertion. But, a HashMap may not necessarily maintain the order of elements as they are inserted. Therefore, when fetched we may get a different order of elements and thus this test is detected as flaky using Nondex tool.

Strategies are added here:

https://github.com/bbelide2/crane4j/blob/b65f7324544381646119be48393f0aa2b3417f2e/crane4j-core/src/test/java/cn/crane4j/core/support/SimpleCrane4jGlobalConfigurationTest.java#L40

HashMap is used here:

https://github.com/bbelide2/crane4j/blob/b65f7324544381646119be48393f0aa2b3417f2e/crane4j-core/src/main/java/cn/crane4j/core/parser/handler/strategy/SimplePropertyMappingStrategyManager.java#L22

Assertion is made here:

https://github.com/bbelide2/crane4j/blob/b65f7324544381646119be48393f0aa2b3417f2e/crane4j-core/src/test/java/cn/crane4j/core/support/SimpleCrane4jGlobalConfigurationTest.java#L41

### Fix

We can change the HashMap to a LinkedHashMap to keep the order deterministic. But this requires a change in the actual code and LinkedHashMap is slightly more computationally expensive than HashMap due to the overhead of maintaining the linked list. But since the order is not required in the code, I only updated the test to compare the result as a set instead of a List. This removes the flakiness in the test without touching the actual code.

**This fix will not affect the code since the change is only made in tests.**

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl crane4j-core -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl crane4j-core test -Dtest=cn.crane4j.core.support.SimpleCrane4jGlobalConfigurationTest#operatePropertyMappingStrategy
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl crane4j-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=cn.crane4j.core.support.SimpleCrane4jGlobalConfigurationTest#operatePropertyMappingStrategy
```

NonDex tests passed after the fix.