### PR TITLE
Fix flaky test in ReflectiveDisassembleOperationHandlerTest

### DIFF
--- a/crane4j-core/src/test/java/cn/crane4j/core/executor/handler/ReflectiveDisassembleOperationHandlerTest.java
+++ b/crane4j-core/src/test/java/cn/crane4j/core/executor/handler/ReflectiveDisassembleOperationHandlerTest.java
@@ -14,9 +14,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -37,24 +39,26 @@ public class ReflectiveDisassembleOperationHandlerTest extends BaseExecutorTest 
     public void process() {
         BeanOperations beanOperations = parseOperations(Bean.class);
         Collection<DisassembleOperation> operations = beanOperations.getDisassembleOperations();
+        List<DisassembleOperation> sortedOperations = new ArrayList<>(operations);
+        sortedOperations.sort(Comparator.comparing(DisassembleOperation::getKey));
 
         Bean root = new Bean();
-        DisassembleOperation operationForBean = CollectionUtils.get(operations, 0);
+        DisassembleOperation operationForBean = CollectionUtils.get(sortedOperations, 0);
         Assert.assertEquals("bean", operationForBean.getKey());
         root.setBean(new Bean());
         checkDisassembledBeans(operationForBean, root, 1);
 
-        DisassembleOperation operationForBeanArray = CollectionUtils.get(operations, 1);
+        DisassembleOperation operationForBeanArray = CollectionUtils.get(sortedOperations, 1);
         Assert.assertEquals("beanArray", operationForBeanArray.getKey());
         root.setBeanArray(new Bean[]{new Bean(), new Bean(), new Bean()});
         checkDisassembledBeans(operationForBeanArray, root, 3);
 
-        DisassembleOperation operationForBeanList = CollectionUtils.get(operations, 2);
+        DisassembleOperation operationForBeanList = CollectionUtils.get(sortedOperations, 2);
         Assert.assertEquals("beanList", operationForBeanList.getKey());
         root.setBeanList(Arrays.asList(new Bean(), new Bean(), new Bean()));
         checkDisassembledBeans(operationForBeanList, root, 3);
 
-        DisassembleOperation operationForBeanMultiList = CollectionUtils.get(operations, 3);
+        DisassembleOperation operationForBeanMultiList = CollectionUtils.get(sortedOperations, 3);
         Assert.assertEquals("beanMultiList", operationForBeanMultiList.getKey());
         root.setBeanMultiList(Arrays.asList(
             Arrays.asList(new Bean[]{new Bean(), new Bean()}, new Bean[]{new Bean(), new Bean()}),


### PR DESCRIPTION
Sort the list "operations" by "DisassembleOperation::getKey" to maintain the order of elements to remove flakiness in the test.

**Flaky test**

```
cn.crane4j.core.executor.handler.ReflectiveDisassembleOperationHandlerTest#process
```

https://github.com/bbelide2/crane4j/blob/679c3f860fb8c1d8e69c64cd7662e9047f7d99ed/crane4j-core/src/test/java/cn/crane4j/core/executor/handler/ReflectiveDisassembleOperationHandlerTest.java#L37

### Problem

Test ```process``` in ```ReflectiveDisassembleOperationHandlerTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:

```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.21 sec <<< FAILURE!
process(cn.crane4j.core.executor.handler.ReflectiveDisassembleOperationHandlerTest)  Time elapsed: 0.004 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<bean[]> but was:<bean[List]>
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at cn.crane4j.core.executor.handler.ReflectiveDisassembleOperationHandlerTest.process(ReflectiveDisassembleOperationHandlerTest.java:44)
```

### Root cause

During the execution of the test, we fetch the fields names of the "Bean" class (which is an inner class in "ReflectiveDisassembleOperationHandlerTest") using ```getDeclaredFields``` function. But, ```getDeclaredFields``` does not guarantee the order of elements it returns, so it can return different order of fields each time. Therefore, the order of elements in ```Collection<DisassembleOperation> operations``` is not guaranteed thus making this test flaky. When tested with NonDex, this test fails as NonDex shuffles order and tests whether the test passes or not.

Bean class:

https://github.com/bbelide2/crane4j/blob/679c3f860fb8c1d8e69c64cd7662e9047f7d99ed/crane4j-core/src/test/java/cn/crane4j/core/executor/handler/ReflectiveDisassembleOperationHandlerTest.java#L91-L91

We fetch the fields here:

https://github.com/bbelide2/crane4j/blob/679c3f860fb8c1d8e69c64cd7662e9047f7d99ed/crane4j-core/src/main/java/cn/crane4j/core/util/ReflectUtils.java#L471-L473


### Fix

I updated the test to sort the ```operations``` before making the assertions so that the order of elements is always the same.

**This fix will not affect the code since the change is only made in tests.**

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl crane4j-core -am -DskipTests 
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl crane4j-core test -Dtest=cn.crane4j.core.executor.handler.ReflectiveDisassembleOperationHandlerTest#process
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl crane4j-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=cn.crane4j.core.executor.handler.ReflectiveDisassembleOperationHandlerTest#process
```

NonDex tests passed after the fix.